### PR TITLE
fix: update publish.yml to enhance permissions for publishing artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to GitHub Container Registry
 
 on:
   push:
-    branches: [main, dev]
+    branches: [ main, dev ]
     paths:
       - "src/**"
       - "config/**"
@@ -19,6 +19,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow permissions. The change grants additional permissions required for publishing and attestation processes. 

- Workflow permissions update:
  * Added `id-token: write` and `attestations: write` permissions to the `.github/workflows/publish.yml` workflow.